### PR TITLE
Add caching for LLM, tools, and graph nodes

### DIFF
--- a/backend/src/agent/configuration/llm_setup.py
+++ b/backend/src/agent/configuration/llm_setup.py
@@ -3,8 +3,11 @@ from dotenv import load_dotenv
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_google_vertexai	import ChatVertexAI
 from langchain_groq import ChatGroq
+from pathlib import Path
+
 from langchain_core.rate_limiters import InMemoryRateLimiter
-from langchain.globals import set_debug
+from langchain.globals import set_debug, set_llm_cache
+from langchain_community.cache import SQLiteCache
 
 load_dotenv()
 
@@ -12,6 +15,10 @@ if os.getenv("GEMINI_API_KEY") is None:
     raise ValueError("GEMINI_API_KEY is not set")
 
 set_debug(True)
+
+# Enable persistent LLM result caching to speed up local development
+cache_path = Path(__file__).resolve().parent.parent / "llm_cache.sqlite"
+set_llm_cache(SQLiteCache(cache_path))
 
 rate_limiter = InMemoryRateLimiter(
     requests_per_second=0.2,  # 1 request every 5 seconds


### PR DESCRIPTION
## Summary
- enable SQLite-backed LLM cache for repeatable generations
- add node-level caching with TTL and custom keys in graph_v2
- wrap Tavily search tool with in-memory cache

## Testing
- `cd backend && make lint` *(fails: Found 683 errors)*
- `cd backend && make test` *(fails: file or directory not found: tests/unit_tests/)*

------
https://chatgpt.com/codex/tasks/task_e_68bac0d95bd88320acd53a7c90f3b5b2